### PR TITLE
[codex] fix Pages deployment guardrails

### DIFF
--- a/.github/workflows/site-ci-deploy.yml
+++ b/.github/workflows/site-ci-deploy.yml
@@ -46,6 +46,9 @@ jobs:
         env:
           JEKYLL_ENV: production
 
+      - name: Verify generated homepage
+        run: bash tools/verify-built-site.sh "_site${{ steps.pages.outputs.base_path }}"
+
       - name: Run HTMLProofer
         run: |
           bundle exec htmlproofer _site \
@@ -159,6 +162,27 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Verify Pages publish mode
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          build_type="$(gh api "repos/${GITHUB_REPOSITORY}/pages" --jq '.build_type')"
+
+          if [[ "$build_type" != "workflow" ]]; then
+            echo "GitHub Pages build_type must be workflow, got: $build_type" >&2
+            echo "Legacy branch publishing can serve raw Jekyll source before the custom deploy finishes." >&2
+            exit 1
+          fi
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+      - name: Verify live homepage
+        run: |
+          bash tools/verify-live-site.sh \
+            "${{ steps.deployment.outputs.page_url }}" \
+            "https://harshityadav.in"

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -4,9 +4,10 @@ const path = require('path');
 const { test, expect } = require('@playwright/test');
 
 const KEYWORD_REGEX = /end\s+of\s+line/i;
+const RAW_FRONT_MATTER_REGEX = /^---\s*[\r\n]+layout:\s*home/im;
 const screenshotPath = process.env.HOMEPAGE_SCREENSHOT_PATH;
 
-test('homepage contains keyword "End of Line"', async ({ page }) => {
+test('homepage renders the generated Jekyll home page', async ({ page }) => {
   // Navigate and check HTTP status
   const response = await page.goto('/', { timeout: 30000 });
 
@@ -15,11 +16,17 @@ test('homepage contains keyword "End of Line"', async ({ page }) => {
     throw new Error(`Smoke test failed: homepage returned HTTP ${status}`);
   }
 
-  // Assert the visible body text contains the keyword
-  await expect(page.locator('body')).toContainText(KEYWORD_REGEX, {
+  const html = await page.content();
+  if (RAW_FRONT_MATTER_REGEX.test(html)) {
+    throw new Error('Smoke test failed: homepage is serving raw Jekyll front matter');
+  }
+
+  await expect(page).toHaveTitle(/Harshit Yadav/i);
+  await expect(page.locator('#sidebar')).toContainText(KEYWORD_REGEX, {
     timeout: 30000,
-    message: 'Smoke test failed: keyword "End of Line" not found in page body',
+    message: 'Smoke test failed: keyword "End of Line" not found in rendered sidebar',
   });
+  await expect(page.locator('#post-list article')).toHaveCount(10);
 
   if (screenshotPath) {
     fs.mkdirSync(path.dirname(screenshotPath), { recursive: true });

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -60,6 +60,8 @@ main() {
   JEKYLL_ENV=production bundle exec jekyll b \
     -d "$SITE_DIR$_baseurl" -c "$_config"
 
+  bash tools/verify-built-site.sh "$SITE_DIR$_baseurl"
+
   # test
   bundle exec htmlproofer "$SITE_DIR" \
     --disable-external \

--- a/tools/verify-built-site.sh
+++ b/tools/verify-built-site.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+site_dir="${1:-_site}"
+homepage="$site_dir/index.html"
+
+if [[ ! -f "$homepage" ]]; then
+  echo "Generated homepage not found: $homepage" >&2
+  exit 1
+fi
+
+if grep -Eq '^---[[:space:]]*$' "$homepage" || grep -Eq '^layout:[[:space:]]*home' "$homepage"; then
+  echo "Generated homepage contains raw Jekyll front matter: $homepage" >&2
+  exit 1
+fi
+
+if ! grep -qi '<!doctype html' "$homepage"; then
+  echo "Generated homepage is missing an HTML doctype: $homepage" >&2
+  exit 1
+fi
+
+if ! grep -q 'id="post-list"' "$homepage"; then
+  echo "Generated homepage is missing the Chirpy post list: $homepage" >&2
+  exit 1
+fi
+
+if ! grep -q 'End of Line' "$homepage"; then
+  echo "Generated homepage is missing the expected site tagline: $homepage" >&2
+  exit 1
+fi
+
+echo "Verified generated homepage: $homepage"

--- a/tools/verify-live-site.sh
+++ b/tools/verify-live-site.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 <url> [url...]" >&2
+  exit 1
+fi
+
+attempts="${VERIFY_LIVE_ATTEMPTS:-18}"
+delay_seconds="${VERIFY_LIVE_DELAY_SECONDS:-20}"
+
+normalize_url() {
+  local url="$1"
+  url="${url%/}/"
+  printf '%s' "$url"
+}
+
+verify_url_once() {
+  local url="$1"
+  local body
+
+  body="$(curl -fsSL --max-time 30 -H 'Cache-Control: no-cache' "$url")"
+
+  if grep -Eq '^---[[:space:]]*$|^layout:[[:space:]]*home' <<<"$body"; then
+    echo "Live homepage is serving raw Jekyll front matter: $url" >&2
+    return 1
+  fi
+
+  if ! grep -qi '<!doctype html' <<<"$body"; then
+    echo "Live homepage is missing an HTML doctype: $url" >&2
+    return 1
+  fi
+
+  if ! grep -q 'id="post-list"' <<<"$body"; then
+    echo "Live homepage is missing the Chirpy post list: $url" >&2
+    return 1
+  fi
+
+  if ! grep -q 'End of Line' <<<"$body"; then
+    echo "Live homepage is missing the expected site tagline: $url" >&2
+    return 1
+  fi
+}
+
+for raw_url in "$@"; do
+  url="$(normalize_url "$raw_url")"
+  cache_busted_url="${url}?deploy_check=${GITHUB_SHA:-manual}-$(date +%s)"
+  verified=false
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if verify_url_once "$url" && verify_url_once "$cache_busted_url"; then
+      echo "Verified live homepage: $url"
+      verified=true
+      break
+    fi
+
+    if ((attempt < attempts)); then
+      echo "Live homepage check failed for $url; retrying in ${delay_seconds}s ($attempt/$attempts)" >&2
+      sleep "$delay_seconds"
+    fi
+  done
+
+  if [[ "$verified" != true ]]; then
+    echo "Live homepage did not become healthy: $url" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- Switch the site pipeline to fail when GitHub Pages is configured for legacy branch publishing instead of workflow publishing.
- Add generated-homepage verification so raw Jekyll front matter cannot pass local or CI builds.
- Strengthen the Playwright smoke test and add post-deploy live homepage verification for the Pages URL and harshityadav.in.

## Root cause
The repository was configured with GitHub Pages `build_type: legacy` from `main:/` while the custom workflow also deployed a generated `_site` artifact. The legacy Pages build could publish source files directly, and the root `index.html` source only contains Jekyll front matter. Existing checks passed because they tested the generated `_site` output, not the actual published URL or the Pages publish mode.

I also updated the repository Pages setting to `build_type: workflow` via the GitHub Pages API so production now uses the custom deploy path.

## Validation
- `bash tools/test.sh`
- `pnpm test`
- `VERIFY_LIVE_ATTEMPTS=1 bash tools/verify-live-site.sh https://harshityadav.in`
- Pages API now returns `build_type: workflow` for `harshityadav95/harshityadav95.github.io`.

## Notes
Jekyll still emits pre-existing duplicate tag/category destination warnings and two `post_url` deprecation warnings. They are unrelated to this fix.
