### PR TITLE
[codex] fix image optimizer feedback loop

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -46,7 +46,12 @@ jobs:
   optimize:
     name: Optimize uploaded images
     runs-on: ubuntu-24.04-arm
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name != 'push' ||
+        (!contains(github.event.head_commit.message, '[ImgBot] Optimize images') &&
+         !contains(github.event.head_commit.message, 'Optimize uploaded images') &&
+         !contains(github.event.head_commit.message, 'chore: optimize uploaded images')))
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What changed

Added a job-level guard to the Optimize Images workflow so pushes created by ImgBot or the Calibre optimizer do not trigger another compression pass. Pull request validation still runs for in-repo PRs.

## Why

Optimizer merge commits were changing image files on `main`, matching the workflow `push.paths` filter and opening another optimizer PR. This caused Calibre and ImgBot output to be recompressed repeatedly.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/optimize-images.yml"); puts "YAML OK"'`\n- `git diff --check`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/optimize-images.yml`