### PR TITLE
fix(ci): remove --with-deps from playwright install

### DIFF
--- a/.github/workflows/site-ci-deploy.yml
+++ b/.github/workflows/site-ci-deploy.yml
@@ -72,7 +72,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install chromium
 
       - name: Run Playwright smoke test
         run: pnpm test


### PR DESCRIPTION
Removes the `--with-deps` flag from Playwright browser installation. The custom/third-party APT repositories on the Ubuntu 24.04-arm runner are currently failing with `Clearsigned file isn't valid` errors, blocking the build. Since the GitHub-hosted runners already contain all required libraries for Chromium, this flag is not needed and removing it bypasses the APT failure entirely.