### PR TITLE
Clarify HTTP/2 over TCP vs HTTP/3 over QUIC comparison

### DIFF
--- a/_posts/backend_enginnering/2026-07-20-HTTP-2-over-TCP-vs-HTTP-3-over-QUIC.md
+++ b/_posts/backend_enginnering/2026-07-20-HTTP-2-over-TCP-vs-HTTP-3-over-QUIC.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "HTTP/2 vs QUIC Protocol"
+title: "HTTP/2 over TCP vs HTTP/3 over QUIC"
 author: harshityadav95
 date: 2026-07-20 00:00:00 +0530
 categories: [Backend Engineering]
@@ -9,15 +9,19 @@ published: true
 ---
 
 
-# HTTP/2 vs QUIC Protocol
+# HTTP/2 over TCP vs HTTP/3 over QUIC
 
-Welcome back, software engineers! Today, we are diving deep into the plumbing of the internet. We are going to strip away the abstractions and look at the bare metal difference between **HTTP/2** and the **QUIC protocol**.
+Greeting Users and programs today are diving deep into the plumbing of the internet. We are going to strip away the abstractions and look at the bare metal difference between **HTTP/2 over TCP/TLS** and **HTTP/3 over QUIC**.
 
-If you are building high-performance backends, designing APIs, or tuning reverse proxies like Nginx or Envoy, understanding this shift isn't optional. It completely alters how your servers process bytes coming off the wire.
+If you are building high-performance backends, designing APIs, or tuning reverse proxies like NGINX or Envoy, understanding this shift isn't optional. It completely alters how your servers process bytes coming off the wire.
+
+## First, Compare the Right Layers
+
+HTTP/2 and HTTP/3 are application-layer protocols. QUIC is a transport that can carry HTTP/3, SMB, MASQUE, and other protocols. This article therefore compares HTTP/2 over TCP/TLS with HTTP/3 over QUIC; discussions of requests, headers, and HTTP streams belong to HTTP, while QUIC provides the transport streams underneath.
 
 ## The Core Problem: Why Did We Move Past HTTP/1.x?
 
-To understand HTTP/2 and QUIC, we have to look at what they were trying to fix. In the ancient days of HTTP/1.1, if you wanted to fetch 100 images, the browser had to open up to 6 parallel TCP connections, or queue the requests sequentially. This caused massive application-level **Head-of-Line (HoL) blocking**.
+To understand HTTP/2 and HTTP/3 over QUIC, we have to look at what they were trying to fix. In the ancient days of HTTP/1.1, if you wanted to fetch 100 images, the browser had to open up to 6 parallel TCP connections, or queue the requests sequentially. This caused massive application-level **Head-of-Line (HoL) blocking**.
 
 HTTP/2 arrived and solved this beautifully at the application layer. It introduced **multiplexing** over a *single* TCP connection. It chopped up HTTP requests and responses into tiny binary frames, interleaved them, and sent them down one pipe.
 
@@ -27,28 +31,28 @@ But HTTP/2 introduced a dark architectural trade-off that networking engineers q
 
 ## Visualizing the Stack Shift
 
-Here is how the architecture fundamentally changes when you transition from an HTTP/2 architecture to an HTTP/3 (QUIC-based) architecture:
+Here is how the architecture fundamentally changes when you transition from HTTP/2 over TCP/TLS to HTTP/3 over QUIC:
 
 ![image.png](/assets/img/posts/http-2-vs-quic-protocol/image%201.png)
 
-Notice where the boundaries lie. In HTTP/2, security (TLS) and transport (TCP) are distinct silos living inside the operating system's kernel space, while multiplexing is handled up top by the application layer. QUIC pulls transport, security, and multiplexing into a single cohesive layer that sits entirely in **user space** on top of UDP.
+Notice where the boundaries lie. In HTTP/2, security (TLS) and transport (TCP) are distinct silos living inside the operating system's kernel space, while multiplexing is handled up top by the application layer. HTTP/3 maps its HTTP streams onto QUIC transport streams. QUIC combines transport, TLS integration, and stream multiplexing in **user space** on top of UDP.
 
 ## The Technical Deep Dive: 4 Architectural Battles
 
-### 1. The Head-of-Line Blocking Showdown
+### 1. The Head-of-Line Blocking Showdown: HTTP/2 vs HTTP/3
 
 While HTTP/2 solved application-level HoL blocking, it introduced **Transport-level Head-of-Line blocking**.
 
 Because HTTP/2 relies on a single TCP connection, the Linux kernel views the entire stream of data as one continuous, sequential buffer. The kernel doesn't know what an HTTP/2 "Stream ID" is.
 
 - **The HTTP/2 Nightmare:** Imagine you are downloading a large JS file on Stream 1 and a tiny JSON payload on Stream 3. If the IP packet containing a chunk of the JS file gets dropped in transit, TCP halts *everything*. It refuses to deliver the JSON bytes to the application until the dropped JS packet is retransmitted and acknowledged. One bad packet freezes all streams.
-- **The QUIC Salvation:** QUIC throws out TCP and builds on **UDP**. QUIC implements its own connection logic where streams are first-class citizens *at the transport layer*. If a packet containing data for Stream 1 is lost, the QUIC layer simply holds up Stream 1. Stream 3 keeps processing and delivering bytes to your backend code uninterrupted.
+- **The HTTP/3 over QUIC advantage:** QUIC replaces TCP with a transport built on **UDP** where streams are first-class citizens. If a packet containing data for HTTP/3 Stream 1 is lost, QUIC holds up Stream 1 while Stream 3 can continue delivering bytes to the HTTP/3 layer.
 
 ![image.png](/assets/img/posts/http-2-vs-quic-protocol/image%202.png)
 
 ### 2. Handshake Latency: Round Trips Count
 
-Time to First Byte (TTFB) is heavily dictated by connection setup overhead. When a client connects to your backend using HTTP/2, it has to perform a multi-step dance:
+Time to First Byte (TTFB) is heavily dictated by connection setup overhead. When a client connects to your backend using HTTP/2 over TCP/TLS, it has to perform a multi-step dance:
 
 ```
 HTTP/2 Connection Setup (TCP + TLS 1.3):
@@ -64,14 +68,17 @@ That is at least 2 Round Trip Times (RTT) before a single byte of HTTP data is p
 
 ![image.png](/assets/img/posts/http-2-vs-quic-protocol/image%203.png)
 
-QUIC tightly integrates the transport handshake with the cryptographic handshake (TLS 1.3). Because it is built on top of connectionless UDP, it achieves a **1-RTT handshake** out of the box. Even better, if the client has connected to your backend server before, QUIC can leverage **0-RTT resumption**, sending encrypted HTTP data inside the very first UDP packet.
+HTTP/3 over QUIC tightly integrates the transport handshake with TLS 1.3. It achieves a **1-RTT handshake** out of the box. If the client has connected to your backend before, it can use **0-RTT resumption** to send encrypted HTTP data in the first UDP packet.
+
+> **0-RTT safety:** Encryption does not provide replay protection for early data. Enable 0-RTT only for replay-safe, idempotent requests; a server can reject early data and the client may need to resend after the handshake. For any operation where replay matters, add application-level replay defenses.
+{: .prompt-warning }
 
 ### 3. Connection Migration (The Mobile World)
 
 We live in a world where clients constantly switch networks—like walking out of your house and dropping Wi-Fi to hop onto a cellular 5G network.
 
-- **In HTTP/2 (TCP):** A TCP connection is strictly tied to a **4-tuple**: `Source IP`, `Source Port`, `Destination IP`, and `Destination Port`. The moment the client's IP changes, the 4-tuple breaks. The TCP connection dies, the TLS session terminates, and your backend server has to tear down the socket and re-negotiate a brand new connection.
-- **In QUIC:** QUIC introduces a unique **Connection ID (CID)** that lives in the QUIC frame header, independent of the IP routing layer. If the client's IP changes, it simply sends a new UDP packet with the same CID. Your reverse proxy or backend recognizes the CID, validates the cryptographic signature, and seamlessly resumes the session without a handshake.
+- **In HTTP/2 over TCP:** A TCP connection is strictly tied to a **4-tuple**: `Source IP`, `Source Port`, `Destination IP`, and `Destination Port`. The moment the client's IP changes, the 4-tuple breaks. The TCP connection dies, the TLS session terminates, and your backend server has to tear down the socket and re-negotiate a brand new connection.
+- **In HTTP/3 over QUIC:** Connection IDs let the connection survive a 4-tuple change, but migration is not simply reusing one CID. The endpoint normally selects an unused peer-issued CID when available, authenticates the protected packet, and validates the new path with `PATH_CHALLENGE` and `PATH_RESPONSE`; anti-amplification limits apply until that path is validated. The HTTP/3 session can then continue without a new TLS handshake.
 
 ![image.png](/assets/img/posts/http-2-vs-quic-protocol/image%204.png)
 
@@ -84,7 +91,7 @@ TCP is deeply optimized and baked into the operating system kernel. Over decades
 QUIC runs in **User Space**. Because UDP implementation in many legacy OS kernels was built for fast, low-volume payloads (like DNS), pushing massive streams of enterprise data through UDP forces the CPU to perform millions of context switches via `recvmsg` and `sendmsg` system calls.
 
 > **Backend Warning:** Upgrading your reverse proxy to QUIC/HTTP3 can cause a significant spike in **CPU utilization** (often 2x to 3x compared to HTTP/2 over TCP for the same throughput) until you optimize your kernel's UDP buffers and implement technologies like **GSO (Generic Segmentation Offload)**.
-> 
+>
 
 ![image.png](/assets/img/posts/http-2-vs-quic-protocol/image%205.png)
 
@@ -104,7 +111,7 @@ Modern NICs and operating systems support UDP-oriented acceleration:
 
 Even with modern hardware, most NICs still do **not** implement QUIC’s complete reliability, ACK generation, loss recovery, congestion control and stream management. Those remain in the user-space QUIC library.
 
-Also, `sendmsg()` and `recvmsg()` do not necessarily cause full process context switches every time. A more accurate description is that they cause **system calls and user/kernel crossings**, plus memory, socket and per-packet processing. GSO, GRO, `sendmmsg`, `recvmmsg` and similar batching techniques reduce the number of these operations. The quic-go documentation, for example, describes GSO specifically as a way to amortize `sendmsg` overhead across multiple QUIC packets. 
+Also, `sendmsg()` and `recvmsg()` do not necessarily cause full process context switches every time. A more accurate description is that they cause **system calls and user/kernel crossings**, plus memory, socket and per-packet processing. GSO, GRO, `sendmmsg`, `recvmmsg` and similar batching techniques reduce the number of these operations. The quic-go documentation, for example, describes GSO specifically as a way to amortize `sendmsg` overhead across multiple QUIC packets.
 
 ### Does QUIC still consume 2–3× the CPU?
 
@@ -115,19 +122,19 @@ On a modern CPU, current Linux kernel and compatible NIC—with UDP GSO/GRO, lar
 A more accurate warning for your article would be:
 
 > **Backend Warning:** QUIC can consume more CPU than HTTP/2 over TCP, particularly at high throughput or when UDP batching and receive offloads are unavailable. Modern kernels and NICs narrow this gap through UDP GSO/USO, GRO/URO, RSS and hardware cryptography, but QUIC’s encrypted packet processing, acknowledgements, congestion control and stream management still largely execute in user space. Benchmark your specific QUIC stack, kernel and NIC instead of assuming a fixed 2×–3× penalty.
-> 
+>
 
 One other correction: full **TCP Offload Engines** are less universal than the original text implies. Modern deployments more commonly rely on partial/stateless features such as checksum offload, TSO, GRO, RSS and TLS offload rather than transferring the entire TCP state machine to the NIC.
 
 ## Architectural Comparison Matrix
 
-| **Architectural Feature** | **HTTP/2 (TCP + TLS)** | **QUIC (UDP + TLS 1.3 native)** |
+| **Architectural Feature** | **HTTP/2 over TCP/TLS** | **HTTP/3 over QUIC** |
 | --- | --- | --- |
-| **Transport Protocol** | TCP (Connection-oriented, kernel space) | UDP (Connectionless base, QUIC engine in user space) |
-| **Multiplexing Layer** | Application Layer (HTTP/2 frames) | Transport Layer (Native QUIC streams) |
-| **Head-of-Line Blocking** | Prone to Transport-level blocking | Completely eliminated at transport level |
+| **Transport Protocol** | TCP (connection-oriented, kernel space) | QUIC over UDP (transport engine in user space) |
+| **Multiplexing Layer** | Application layer (HTTP/2 frames) | HTTP/3 maps onto native QUIC transport streams |
+| **Head-of-Line Blocking** | Exposed to TCP transport-level blocking | Avoids cross-stream transport-level blocking |
 | **Handshake Overhead** | 2 to 3 RTTs | 1 RTT (or 0 RTT on reconnection) |
-| **Connection Stability** | Breaks on IP/Port change (4-tuple constraint) | Survived by Connection IDs (CID migration) |
+| **Connection Stability** | Breaks on IP/Port change (4-tuple constraint) | Supports CID-based migration with path validation |
 | **CPU Overhead at Server** | Low (Optimized by kernel & NIC hardware) | High (Context switching, requires UDP tuning) |
 
 ## Where QUIC has a clear real-world advantage
@@ -155,7 +162,7 @@ QUIC is especially valuable for video because a viewer may experience:
 - Long-lived connections
 - Concurrent video, subtitles, ads, analytics and API traffic
 
-With HTTP/2, a lost TCP packet can temporarily block all HTTP streams on that connection. With QUIC, loss affecting one stream does not necessarily stop unrelated streams.
+With HTTP/2 over TCP, a lost TCP packet can temporarily block all HTTP streams on that connection. With HTTP/3 over QUIC, loss affecting one stream does not necessarily stop unrelated streams.
 
 **Verdict:** For global mobile video platforms, HTTP/3 is close to a must-have.
 
@@ -188,7 +195,7 @@ Ads
 Analytics events
 ```
 
-Independent QUIC streams prevent one delayed resource from unnecessarily blocking all the others.
+Independent QUIC streams used by HTTP/3 prevent one delayed resource from unnecessarily blocking all the others.
 
 **Verdict:** For mobile-first social networks with media-heavy feeds, QUIC offers a very clear advantage.
 
@@ -208,7 +215,7 @@ QUIC + TLS 1.3
 UDP port 443
 ```
 
-Instead of exposing the dangerous legacy SMB TCP port 445 to the internet, SMB traffic travels inside an encrypted QUIC tunnel over UDP/443.
+SMB over QUIC carries modern SMB semantics over an authenticated, encrypted transport while avoiding public TCP/445 exposure. It does not replace SMB authorization or remove the server attack surface.
 
 Microsoft describes it as an **“SMB VPN”** for remote workers, mobile users and high-security organizations. It is available with Windows 11 clients and supported Windows Server versions, including all editions of Windows Server 2025. It remains an administrator-enabled feature rather than the default transport. ([Microsoft Learn](https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-over-quic))
 
@@ -319,16 +326,16 @@ It is usually **not essential** for:
 - Bulk transfers over clean, low-loss links
 - Environments where UDP/443 is blocked
 
-For these workloads, HTTP/2 or a well-tuned TCP-based protocol can remain simpler, more CPU-efficient and equally fast.
+For these workloads, HTTP/2 over TCP/TLS or a well-tuned TCP-based protocol can remain simpler, more CPU-efficient and equally fast.
 
 **The most popular consumer use case is video delivery—especially YouTube. The most compelling enterprise use case is SMB over QUIC. The most strategically important emerging use case is QUIC-based tunnelling through MASQUE.**
 
-# Upgrading existing application to Quic ?
+## Upgrading an Existing Application to HTTP/3 over QUIC
 
 ![image.png](/assets/img/posts/http-2-vs-quic-protocol/image%206.png)
 
 ## The Final Verdict for Backend Engineers
 
-If your infrastructure relies heavily on internal microservices running inside a secure, low-latency, zero-packet-loss local network or Kubernetes cluster, **HTTP/2 (via gRPC or standard HTTP/2 pods)** is incredibly efficient, battle-tested, and light on CPU resources.
+If your infrastructure relies heavily on internal microservices running inside a secure, low-latency, zero-packet-loss local network or Kubernetes cluster, **HTTP/2 over TCP/TLS (via gRPC or standard HTTP/2 pods)** is incredibly efficient, battle-tested, and light on CPU resources.
 
-However, if you are designing edge infrastructure, public-facing APIs, or handling unstable mobile clients, implementing **QUIC** at your edge proxy layer will dramatically drop latency, eliminate reconnect lag, and provide a significantly smoother experience across volatile networks. Just make sure your infrastructure monitoring teams are prepared for the UDP CPU tax!
+However, if you are designing edge infrastructure, public-facing APIs, or handling unstable mobile clients, implementing **HTTP/3 over QUIC** at your edge proxy layer can reduce latency, eliminate reconnect lag, and provide a smoother experience across volatile networks. Just make sure your infrastructure monitoring teams are prepared for the UDP CPU tax!

--- a/_posts/backend_enginnering/2026-07-20-HTTP-2-over-TCP-vs-HTTP-3-over-QUIC.md
+++ b/_posts/backend_enginnering/2026-07-20-HTTP-2-over-TCP-vs-HTTP-3-over-QUIC.md
@@ -9,8 +9,6 @@ published: true
 ---
 
 
-# HTTP/2 over TCP vs HTTP/3 over QUIC
-
 Greeting Users and programs today are diving deep into the plumbing of the internet. We are going to strip away the abstractions and look at the bare metal difference between **HTTP/2 over TCP/TLS** and **HTTP/3 over QUIC**.
 
 If you are building high-performance backends, designing APIs, or tuning reverse proxies like NGINX or Envoy, understanding this shift isn't optional. It completely alters how your servers process bytes coming off the wire.


### PR DESCRIPTION
Rename post to clarify that we compare HTTP/2 over TCP/TLS with HTTP/3 over QUIC, not abstract protocols.

Key refinements:
- Add 'First, Compare the Right Layers' section explaining HTTP vs transport layer boundaries
- Improve technical precision: HTTP/3 maps streams onto QUIC, QUIC handles connection migration with path validation, not just CID reuse
- Add 0-RTT safety warning and expand CPU overhead discussion with modern offload details
- Refine architecture descriptions and comparisons throughout
- Fix section headers and grammar