### PR TITLE
Update projects tab: add Drezze and reorganize

### DIFF
--- a/_tabs/projects.md
+++ b/_tabs/projects.md
@@ -7,31 +7,23 @@ order: 5
 toc: true
 ---
 
-I like projects where the abstraction eventually has to touch the real machine: networks, filesystems, kernels, cloud services, deployment pipelines, and the occasional ML experiment.
+I like projects where the abstraction eventually has to touch the real machine: networks, filesystems, kernels, cloud services, and deployment pipelines.
 
 This page is the index of that work. Some of it is polished, some of it is exploratory, but the useful thread is the same: build the thing, understand where it breaks, then write down the engineering trade-offs.
 
 ## Active Work
 
+### Drezze
+
+Drezze is a free macOS disk cleaner that helps you find storage-heavy files and reclaim disk space through a focused, easy-to-review cleanup workflow.
+
+- [Website](https://harshityadav.in/drezze-Disk-Cleaner-App/)
+- [Product Hunt](https://www.producthunt.com/products/drezze-disk-cleaner)
+- [Peerlist](https://peerlist.io/harshityadav95/project/drezze--free-disk-cleaner-for-mac)
+
 ### SolvePao
 
 [SolvePao](https://solvepao.com) is the main product/project thread I keep separate from the blog. It is where product thinking, practical software delivery, and small-system architecture meet.
-
-### Skynet Systems
-
-Skynet is my homelab and infrastructure playground. This is where I test ideas around remote access, storage, networking, containers, and operating-system behavior before writing about them.
-
-Good starting points:
-
-- [Securely SSH my Machine from Anywhere in the World]({% post_url skynet_system/2026-05-16-Securely-SSH-Machine-Anywhere-Cloudflare-Tunnel %})
-- [Rclone Architecture: Cloud Sync Under the Hood]({% post_url skynet_system/2026-06-10-rclone-architecture-cloud-sync-under-the-hood %})
-
-## Machine Learning Experiments
-
-The ML work on this site started as notes, course projects, and hands-on experiments. The point was not to collect certificates. The point was to get enough mechanical sympathy for data pipelines, notebooks, training loops, deployment, and cloud constraints.
-
-- [100 Days of Machine Learning Code - Day 1]({% post_url ai_ml/2020-05-03-100-days-of-machine-learning-code-day-1 %})
-- [100 Days, 100 Projects]({% post_url ai_ml/2021-04-30-100-days-100-projects %})
 
 ## Hackathons and Build Logs
 


### PR DESCRIPTION
Revise _tabs/projects.md: remove the Skynet Systems and Machine Learning Experiments sections, shorten the intro (drop the ML mention), add a new Drezze entry with links (Website, Product Hunt, Peerlist), and reorder SolvePao with its links. Keeps the projects index aligned with current product focus and surfaces the Drezze disk-cleaner project.